### PR TITLE
Fix `wp` pseudo-executable to use the proper passed argument

### DIFF
--- a/config/bin/wp
+++ b/config/bin/wp
@@ -2,5 +2,5 @@
 
 cid=$(docker ps -q)
 if [[ ! $cid =~ $'\n' ]]; then
-  docker exec $cid wp --allow-root ${@:2}
+  docker exec $cid wp --allow-root ${@:1}
 fi


### PR DESCRIPTION
See #4